### PR TITLE
Fix issue with insufficient data type

### DIFF
--- a/app/src/main/java/com/mobilecoronatracker/data/persistence/entity/AccumulatedData.kt
+++ b/app/src/main/java/com/mobilecoronatracker/data/persistence/entity/AccumulatedData.kt
@@ -17,7 +17,7 @@ data class AccumulatedData(
     val deaths: Int = 0,
     val recovered: Int = 0,
     val critical: Int = 0,
-    val tests: Int = 0,
+    val tests: Long = 0,
     @ColumnInfo(name = "today_cases") val todayCases: Int = 0,
     @ColumnInfo(name = "today_deaths") val todayDeaths: Int = 0,
     @ColumnInfo(name = "cases_per_million") val casesPerMillion: Double = 0.0,

--- a/app/src/main/java/com/mobilecoronatracker/model/GeneralReportModelable.kt
+++ b/app/src/main/java/com/mobilecoronatracker/model/GeneralReportModelable.kt
@@ -7,7 +7,7 @@ interface GeneralReportModelable {
     var deaths: Int
     var recovered: Int
     var critical: Int
-    var tests: Int
+    var tests: Long
     var todayCases: Int
     var todayDeaths: Int
     var casesPerMillion: Double

--- a/app/src/main/java/com/mobilecoronatracker/model/impl/GeneralReportModel.kt
+++ b/app/src/main/java/com/mobilecoronatracker/model/impl/GeneralReportModel.kt
@@ -9,7 +9,7 @@ class GeneralReportModel(
     override var deaths: Int = 0,
     override var recovered: Int = 0,
     override var critical: Int = 0,
-    override var tests: Int = 0,
+    override var tests: Long = 0,
     override var todayCases: Int = 0,
     override var todayDeaths: Int = 0,
     override var casesPerMillion: Double = 0.0,
@@ -18,7 +18,7 @@ class GeneralReportModel(
     override var affectedCountries: Int = 0
 ) : GeneralReportModelable {
     constructor(data: CovidCumulatedData) : this(
-        data.cases, data.deaths, data.recovered, data.critical, data.tests, data.todayCases,
+        data.cases, data.deaths, data.recovered, data.critical, data.tests as Long, data.todayCases,
         data.todayDeaths, data.casesPerMillion, data.deathsPerMillion, data.testPerMillion,
         data.affectedCountries
     )

--- a/app/src/main/java/com/mobilecoronatracker/model/pojo/CovidCumulatedData.kt
+++ b/app/src/main/java/com/mobilecoronatracker/model/pojo/CovidCumulatedData.kt
@@ -5,7 +5,7 @@ data class CovidCumulatedData(
     val deaths: Int = 0,
     val recovered: Int = 0,
     val critical: Int = 0,
-    val tests: Int = 0,
+    val tests: Long = 0,
     val todayCases: Int = 0,
     val todayDeaths: Int = 0,
     val casesPerMillion: Double = 0.0,

--- a/app/src/main/java/com/mobilecoronatracker/ui/accumulatedcharts/AccumulatedChartsViewModel.kt
+++ b/app/src/main/java/com/mobilecoronatracker/ui/accumulatedcharts/AccumulatedChartsViewModel.kt
@@ -41,7 +41,7 @@ class AccumulatedChartsViewModel(
             AccumulatedChartsViewModelable.GlobalDataWithToday(
                 today.cases, today.todayCases, today.deaths, today.todayDeaths,
                 today.cases - today.deaths - today.recovered, today.recovered,
-                today.recovered - yesterday.recovered, today.critical, today.tests
+                today.recovered - yesterday.recovered, today.critical,  today.tests.toInt()
             )
         )
     }


### PR DESCRIPTION
Covid is high. Number of people tested around the world exceeded
maximum value that Int is capable to hold. Quick fix changes data
type from Int to Long where necessary.